### PR TITLE
Add methods to grab recent meta keys

### DIFF
--- a/lib/rosette/data_stores/active_record/migrations/20150217170559_add_index_on_repo_name_and_meta_key.rb
+++ b/lib/rosette/data_stores/active_record/migrations/20150217170559_add_index_on_repo_name_and_meta_key.rb
@@ -1,0 +1,11 @@
+# encoding: UTF-8
+
+class AddIndexOnRepoNameAndMetaKey < ActiveRecord::Migration
+  def up
+    add_index :phrases, [:repo_name, :meta_key]
+  end
+
+  def down
+    remove_index :phrases, column: [:repo_name, :meta_key]
+  end
+end

--- a/lib/rosette/data_stores/active_record/migrations/20150219105515_add_index_on_commit_id_and_commit_datetime.rb
+++ b/lib/rosette/data_stores/active_record/migrations/20150219105515_add_index_on_commit_id_and_commit_datetime.rb
@@ -1,0 +1,11 @@
+# encoding: UTF-8
+
+class AddIndexOnCommitIdAndCommitDatetime < ActiveRecord::Migration
+  def up
+    add_index :commit_logs, [:commit_id, :commit_datetime]
+  end
+
+  def down
+    remove_index :commit_logs, column: [:commit_id, :commit_datetime]
+  end
+end

--- a/lib/rosette/data_stores/active_record/migrations/20150219105646_add_index_on_commit_datetime.rb
+++ b/lib/rosette/data_stores/active_record/migrations/20150219105646_add_index_on_commit_datetime.rb
@@ -1,0 +1,11 @@
+# encoding: UTF-8
+
+class AddIndexOnCommitDatetime < ActiveRecord::Migration
+  def up
+    add_index :commit_logs, [:commit_datetime]
+  end
+
+  def down
+    remove_index :commit_logs, column: [:commit_datetime]
+  end
+end

--- a/lib/rosette/data_stores/active_record_data_store.rb
+++ b/lib/rosette/data_stores/active_record_data_store.rb
@@ -206,6 +206,23 @@ module Rosette
         end
       end
 
+      def most_recent_key_for_meta_key(repo_name, meta_key)
+        with_connection do
+          phrase_model
+            .select(phrase_model.arel_table[:key])
+            .joins(
+              phrase_model.arel_table.join(commit_log_model.arel_table).on(
+                phrase_model.arel_table[:commit_id].eq(commit_log_model.arel_table[:commit_id])
+              ).join_sources
+            )
+            .where(repo_name: repo_name, meta_key: meta_key)
+            .order(:commit_datetime)
+            .reverse_order
+            .first
+            .key
+        end
+      end
+
       def unique_commit_count(repo_name)
         with_connection do
           count = Arel::Nodes::NamedFunction.new(

--- a/lib/rosette/data_stores/active_record_data_store.rb
+++ b/lib/rosette/data_stores/active_record_data_store.rb
@@ -195,11 +195,15 @@ module Rosette
         with_connection do
           if block_given?
             query = phrase_model
+              .select(
+                Arel::Nodes::NamedFunction.new(
+                  'DISTINCT', [phrase_model[:meta_key]]
+                )
+              )
               .where(repo_name: repo_name)
-              .group(:meta_key)
 
             query.find_in_batches(batch_size: CHUNK_SIZE) do |phrase|
-              yield phrase
+              yield phrase.meta_key
             end
           else
             to_enum(__method__, repo_name)

--- a/lib/rosette/data_stores/active_record_data_store.rb
+++ b/lib/rosette/data_stores/active_record_data_store.rb
@@ -191,6 +191,26 @@ module Rosette
         end
       end
 
+      def each_unique_meta_key(repo_name)
+        with_connection do
+          if block_given?
+            query = phrase_model
+              .select(
+                Arel::Nodes::NamedFunction.new(
+                  'DISTINCT', [phrase_model[:meta_key]]
+                )
+              )
+              .where(repo_name: repo_name)
+
+            query.find_in_batches(batch_size: CHUNK_SIZE) do |phrase|
+              yield phrase.meta_key
+            end
+          else
+            to_enum(__method__, repo_name)
+          end
+        end
+      end
+
       def unique_commit_count(repo_name)
         with_connection do
           count = Arel::Nodes::NamedFunction.new(

--- a/lib/rosette/data_stores/active_record_data_store.rb
+++ b/lib/rosette/data_stores/active_record_data_store.rb
@@ -195,16 +195,11 @@ module Rosette
         with_connection do
           if block_given?
             query = phrase_model
-              .select(
-                Arel::Nodes::NamedFunction.new(
-                  'DISTINCT', [phrase_model[:meta_key]]
-                )
-              )
+              .select([:id, :meta_key])
               .where(repo_name: repo_name)
-
-            query.find_in_batches(batch_size: CHUNK_SIZE) do |phrase|
-              yield phrase.meta_key
-            end
+              .group(:meta_key)
+              .pluck(:meta_key)
+              .each { |mk| yield mk }
           else
             to_enum(__method__, repo_name)
           end

--- a/lib/rosette/data_stores/active_record_data_store.rb
+++ b/lib/rosette/data_stores/active_record_data_store.rb
@@ -195,15 +195,11 @@ module Rosette
         with_connection do
           if block_given?
             query = phrase_model
-              .select(
-                Arel::Nodes::NamedFunction.new(
-                  'DISTINCT', [phrase_model[:meta_key]]
-                )
-              )
               .where(repo_name: repo_name)
+              .group(:meta_key)
 
             query.find_in_batches(batch_size: CHUNK_SIZE) do |phrase|
-              yield phrase.meta_key
+              yield phrase
             end
           else
             to_enum(__method__, repo_name)

--- a/spec/active_record_data_store_spec.rb
+++ b/spec/active_record_data_store_spec.rb
@@ -294,6 +294,36 @@ describe ActiveRecordDataStore do
     end
   end
 
+  describe '#each_unique_meta_key' do
+    it 'yields once for each unique meta key for the given repo' do
+      phrases = create_list(:phrase, 3, :with_meta_key)
+      dup_phrase = create(:phrase, meta_key: phrases.first.meta_key)
+
+      datastore.each_unique_meta_key(repo_name).to_a.tap do |phrases|
+        expect(phrases.size).to eq(3)
+        expect(phrases.uniq.size).to eq(3)
+      end
+    end
+  end
+
+  describe '#most_recent_key_for_meta_key' do
+    it 'returns the most recently created key for the given meta key' do
+      old_commit_log = create(:commit_log, commit_datetime: DateTime.now - 5)
+      new_commit_log = create(:commit_log, commit_datetime: DateTime.now)
+
+      old_phrase = create(:phrase, {
+        meta_key: 'foo', commit_id: old_commit_log.commit_id
+      })
+
+      new_phrase = create(:phrase, {
+        meta_key: 'foo', commit_id: new_commit_log.commit_id
+      })
+
+      key = datastore.most_recent_key_for_meta_key(repo_name, 'foo')
+      expect(key).to eq(new_phrase.key)
+    end
+  end
+
   describe '#unique_commit_count' do
     it 'returns the number of unique commits in the database' do
       commit_ids = create_list(:phrase, 3).map(&:commit_id)


### PR DESCRIPTION
In order to build our pseudo-translation memory, we need to grab all unique meta keys as well as the most recent key for each one.
